### PR TITLE
#63 Hiding Affordable Housing

### DIFF
--- a/fees/eastern-neighborhoods-infrastructure/template.html
+++ b/fees/eastern-neighborhoods-infrastructure/template.html
@@ -33,10 +33,10 @@
         <label for="pdrToNonResReplacement">PDR to Non-Residential (GFA)</label>
         <input type="number" class="form-control" id="pdrToNonResReplacement" data-bind="value: fee.pdrToNonResReplacement, valueUpdate: 'keyup'">
 
-        <hr>
+        <!--<hr>
         <label for="allAffordable">100% Affordable Housing Project</label>&nbsp;&nbsp;
         <input type="checkbox"  aria-hidden="true" id="allAffordable" data-bind="checked: fee.allAffordable, checkedUpdate: 'keyup'">
-
+        -->
 
     </div>
 </form>


### PR DESCRIPTION
Might implement this later but hiding for now as there are waivers for certain types of affordable housing projects that are difficult to define.  The affordable housing experts may need to calculate these manually.