### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,7 +464,7 @@
                     for the final fees calculated and assessed by authorized
                     City staff. The latest development impact fee schedule may
                     be reviewed at
-                    <a href="http://sf-planning.org/impact-fees" target="_blank">http://sf-planning.org/impact-fees</a>
+                    <a href="https://sfplanning.org/project/development-impact-fees" target="_blank">https://sfplanning.org/project/development-impact-fees</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Corrected sf-planning.org URLs that broke due to www.sf-planning.org redesign.