### PR TITLE
Turning on Central SoMa fees for testing

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -4,7 +4,9 @@
         "eastern-neighborhoods-non-residential-open-space",
         "balboa-park-infrastructure",
         "bicycle-parking-in-lieu",
-
+        "central-soma-community-facilities",
+        "central-soma-infrastructure",
+        
         "citywide-childcare-hotel-office",
         "citywide-childcare-residential",
         "downtown-park-fee",


### PR DESCRIPTION
Turning on Central SoMa fees for testing now that they have been added to the Impact Fee Schedule.